### PR TITLE
Fix padding of single-digit codes to match Python's implementation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,11 @@ var binascii = (function(){
 
   var hexlify = function(str) {
     var result = '';
+    var padding = '00';
     for (var i=0, l=str.length; i<l; i++) {
-      result += str.charCodeAt(i).toString(16);
+      var digit = str.charCodeAt(i).toString(16);
+      var padded = (padding+digit).slice(-2);
+      result += padded;
     }
     return result;
   };

--- a/tests/binascii-tests.js
+++ b/tests/binascii-tests.js
@@ -24,3 +24,6 @@ assert.equal(ba.unhexlify('377abcaf271c'), '7z¼¯\'\u001c');
 // Aliases
 assert(ba.unhexlify === ba.a2b_hex);
 assert(ba.hexlify === ba.b2a_hex);
+
+// Ensure single-digit codes are correctly padded
+assert.equal(ba.hexlify('\n'), '0a');


### PR DESCRIPTION
This is the simple fix I was proposing to match python's padding. I've added an additional test, verifying it was failing before. Hope this helps.