### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "binascii",
   "version": "0.0.2",
   "author": "Michał Budzyński <michal@virtualdesign.pl>",
+  "license": "MIT",
   "repository": "git@github.com:michalbe/binascii.git",
   "devDependencies": {
     "assert": "^1.1.1",


### PR DESCRIPTION
Adding the license field to the package.json makes it much easier for automated tooling to determine the license type.